### PR TITLE
avoid sending one statement to multiple bodies

### DIFF
--- a/draft-iab-rfc4053bis.md
+++ b/draft-iab-rfc4053bis.md
@@ -215,8 +215,9 @@ From-Liaison-Contact ("Send Reply to"):
   in the receiving organisation, following their internal process.
 
 To:
-: The statement needs to indicate to which body it is sent. A statement may be sent to multiple bodies or
-   groups within one body.
+: The statement needs to indicate to which body it is sent. A statement may be sent to multiple
+   groups within one body or even multiple bodies. However, it is rather recommended to send separate
+   statements to different bodies to avoid unnessary interconnections.
 
 To-Contact:
 : One or more email addresses from the receiving body to which this

--- a/draft-iab-rfc4053bis.md
+++ b/draft-iab-rfc4053bis.md
@@ -215,9 +215,9 @@ From-Liaison-Contact ("Send Reply to"):
   in the receiving organisation, following their internal process.
 
 To:
-: The statement needs to indicate to which body it is sent. A statement may be sent to multiple
-   groups within one body or even multiple bodies. However, it is rather recommended to send separate
-   statements to different bodies to avoid unnessary interconnections.
+: The statement needs to indicate to which body it is sent to. A statement may be sent to multiple
+   groups within one body or even multiple bodies. However, it is recommended to send separate
+   statements to different bodies to avoid unnecessary interconnections.
 
 To-Contact:
 : One or more email addresses from the receiving body to which this


### PR DESCRIPTION
Based on discussion with the tool teams, this recommendation would be useful to simply the review process. I think it's the right thing to do also to avoid large conflated interconnections. Usually there are also practical reason, such as different format and process requirement by the other SDOs.